### PR TITLE
Update Travis integration, add .release script

### DIFF
--- a/.release
+++ b/.release
@@ -1,0 +1,4 @@
+#!/bin/sh
+# This file is executed by the `release` script from
+# https://github.com/gap-system/ReleaseTools
+rm -rf .travis.yml .codecov.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,31 +1,30 @@
 language: c
-env:
-  global:
-    - GAPROOT=gaproot
-    - COVDIR=coverage
 
 addons:
   apt_packages:
     - libgmp-dev
     - libreadline-dev
-    - libgmp-dev:i386
-    - libreadline-dev:i386
-    - gcc-multilib
-    - g++-multilib
+    - zlib1g-dev
 
 matrix:
   include:
-    - env: GAPBRANCH=master ABI=64
-    - env: GAPBRANCH=master ABI=32
-    - env: GAPBRANCH=stable-4.9
+    - env: GAPBRANCH=master
     - env: GAPBRANCH=stable-4.10
+    - env: GAPBRANCH=stable-4.9
+    - env: GAPBRANCH=master ABI=32
+      addons:
+        apt_packages:
+          - libgmp-dev:i386
+          - libreadline-dev:i386
+          - zlib1g-dev:i386
+          - gcc-multilib
+          - g++-multilib
 
 branches:
   only:
     - master
 
 before_script:
-  - export GAPROOT="$HOME/gap"
   - git clone https://github.com/gap-system/pkg-ci-scripts.git scripts
   - scripts/build_gap.sh
 script:


### PR DESCRIPTION
The .release script is called by ReleaseTools when making a release, and here
is used to remove .travis.yml and .codecov.yml from the release tarball (the
.release script itself is automatically removed).