### PR TITLE
Ensure nauty build failures are detected properly

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -1,7 +1,7 @@
 binaries:
 	mkdir -p bin/@GAPARCH@/
-	( cd nauty22; rm -f *.o config.log config.cache config.status makefile; ./configure; make dreadnautB; mv dreadnautB ../bin/@GAPARCH@; chmod 755 ../bin/@GAPARCH@/dreadnautB; rm -f *.o )
+	cd nauty22 && rm -f *.o config.log config.cache config.status makefile && ./configure && make dreadnautB && mv dreadnautB ../bin/@GAPARCH@ && chmod 755 ../bin/@GAPARCH@/dreadnautB && rm -f *.o
 
 clean:
-	( cd nauty22; make clean )
+	( cd nauty22 && make clean )
 	rm -rf bin/@GAPARCH@


### PR DESCRIPTION
By using `&&` to chain the commands in the build script, a failure in
any script (e.g. in `configure`) causes the whole thing to abort, and
report a non-zero exit code.

Previously, if e.g. configure failed, the build processes nevertheless
proceeded, and ultimately always reported success. This is annoying for
continuous integration, but also can be confusing for users.