### PR TITLE
Ignore the nauty directory when calculating code coverage

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -13,6 +13,7 @@ comment:
   behavior: default
 
 ignore:
+  - "nauty"
   - "PackageInfo.g"
   - "init.g"
   - "read.g"


### PR DESCRIPTION
We can assume that the purpose of the tests in the package are to test GRAPE rather than nauty.