### PR TITLE
Add initial GitHub Actions support

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  - push
+  - pull_request
+
+jobs:
+  test:
+    name: "GAP ${{ matrix.gap-branch }}"
+    runs-on: ubuntu-latest
+    # Don't run this twice on PRs for branches pushed to the same repository
+    if: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) }}
+    strategy:
+      fail-fast: false
+      matrix:
+        gap-branch:
+          - master
+          - stable-4.11
+          - stable-4.10
+          - stable-4.9
+    steps:
+      - uses: actions/checkout@v2
+      - uses: gap-actions/setup-gap-for-packages@v1
+        with:
+          GAPBRANCH: ${{ matrix.gap-branch }}
+      - uses: gap-actions/run-test-for-packages@v1


### PR DESCRIPTION
This replicates the Travis jobs that test Grape in the normal way with GAP master, stable-4.11, stable-4.10, and stable-4.9. It still uploads its results to codecov.

It still lacks the 32-bit job and the `GRAPE_NAUTY=false` job.