### PR TITLE
Improve the names of GitHub Actions jobs

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   test:
-    name: "${{ matrix.abi }}-bit / GAP ${{ matrix.gap-branch }} / nauty=${{ matrix.nauty }}"
+    name: "${{ matrix.abi }}-bit / ${{ matrix.engine }} / GAP ${{ matrix.gap-branch }}"
     runs-on: ubuntu-latest
     # Don't run this twice on PRs for branches pushed to the same repository
     if: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) }}
@@ -20,24 +20,24 @@ jobs:
           - stable-4.9
         abi:
           - 64
-        nauty:
-          - true
+        engine:
+          - nauty
 
         include:
           - gap-branch: master
             abi: 32
-            nauty: true
+            engine: nauty
           - gap-branch: master
             abi: 64
-            nauty: false
+            engine: bliss
 
     env:
-      GRAPE_NAUTY: ${{ matrix.nauty }}
+      GRAPE_NAUTY: ${{ matrix.engine == 'nauty' }}
 
     steps:
       - uses: actions/checkout@v2
       - name: "Install bliss"
-        if: ${{ matrix.nauty == false }}
+        if: ${{ matrix.engine == 'bliss' }}
         run: sudo apt-get install bliss
       - uses: gap-actions/setup-gap-for-packages@v1
         with:


### PR DESCRIPTION
(Sorry for the multiple PRs @lhsoicher! This will probably my last one on GitHub Actions for now.)

This changes the names of the individual jobs in GitHub Actions to:
```
64-bit / nauty / GAP master
64-bit / nauty / GAP stable-4.11
64-bit / nauty / GAP stable-4.10
64-bit / nauty / GAP stable-4.9
32-bit / nauty / GAP master
64-bit / bliss / GAP master
```
instead of
```
64-bit / GAP master / nauty=true
64-bit / GAP stable-4.11 / nauty=true
64-bit / GAP stable-4.10 / nauty=true
64-bit / GAP stable-4.9 / nauty=true
32-bit / GAP master / nauty=true
64-bit / GAP master / nauty=false
```
(In particular, note the plain use of 'nauty' and 'bliss' rather than 'nauty=true/false').

This is what you see in the "Actions" tab of the repository, such as https://github.com/gap-packages/grape/actions/runs/571152275. I think this is nicer.