### PR TITLE
GitHub Actions: remove tests against GAP stable-4.9 and stable-4.10

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -16,8 +16,6 @@ jobs:
         gap-branch:
           - master
           - stable-4.11
-          - stable-4.10
-          - stable-4.9
         abi:
           - 64
         engine:


### PR DESCRIPTION
GRAPE requires GAP 4.11.0, so there isn't any point in checking against these GAP branches.