### PR TITLE
Add License field to PackageInfo.g, rename license file

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -15,6 +15,9 @@ Version := "4.9.0",
 ##  Release date of the current version in dd/mm/yyyy format.
 Date := "09/12/2022",
 
+##  Machine readable license information (as an SPDX identifier)
+License := "Apache-2.0 AND GPL-2.0-or-later",
+
 SourceRepository := rec(
     Type := "git",
     URL :=  "https://github.com/gap-packages/grape",


### PR DESCRIPTION
Also update reference URL to use http sand point at GPL 2.0

This is not urgent at all, just would be nice to have in some future release.