### PR TITLE
Overhaul build system

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -1,7 +1,27 @@
-binaries:
-	mkdir -p bin/@GAPARCH@/
-	cd nauty2_8_6 && rm -f *.o config.log config.cache config.status makefile && ./configure && make dreadnaut && mv dreadnaut ../bin/@GAPARCH@ && chmod 755 ../bin/@GAPARCH@/dreadnaut && rm -f *.o
+# read GAP's build settings
+GAPPATH = @GAPPATH@
+include $(GAPPATH)/sysinfo.gap
 
-clean:
-	( cd nauty2_8_6 && make clean )
-	rm -rf bin/@GAPARCH@
+NAUTYDIR = nauty2_8_6
+BINDIR = bin/$(GAParch)
+
+binaries: Makefile
+	mkdir -p $(BINDIR)
+	cd $(NAUTYDIR) && rm -f *.o config.log config.cache config.status makefile
+	# configure with --enable-generic to turn off -march=native which causes
+	# problems when installing the result
+	cd $(NAUTYDIR) && ./configure --enable-generic
+	make -C $(NAUTYDIR) dreadnaut
+	mv $(NAUTYDIR)/dreadnaut $(BINDIR)
+	chmod 755 $(BINDIR)/dreadnaut
+	rm -f $(NAUTYDIR)/*.o
+
+clean: Makefile
+	make -C $(NAUTYDIR) clean
+	rm -rf $(BINDIR)
+
+.PHONY: binaries clean
+
+# re-run configure if configure, Makefile.in or GAP itself changed
+Makefile: configure Makefile.in $(GAPPATH)/sysinfo.gap
+	./configure "$(GAPPATH)"

--- a/configure
+++ b/configure
@@ -1,8 +1,34 @@
 #!/bin/sh
 # usage: configure gappath
-# this script creates a `Makefile' from `Makefile.in' 
+# this script creates a `Makefile' from `Makefile.in'
 
 set -e
 
-. ${1:-"../.."}/sysinfo.gap
-sed -e "s?@GAPARCH@?$GAParch?g" Makefile.in >Makefile
+GAPPATH=../..
+while test "$#" -ge 1 ; do
+  option="$1" ; shift
+  case "$option" in
+    --with-gaproot=*) GAPPATH=${option#--with-gaproot=}; ;;
+    -*)               echo "ERROR: unsupported argument $option" ; exit 1;;
+    *)                GAPPATH="$option" ;;
+  esac
+done
+
+if test ! -r "$GAPPATH/sysinfo.gap" ; then
+    echo
+    echo "No file $GAPPATH/sysinfo.gap found."
+    echo
+    echo "Usage: ./configure [GAPPATH]"
+    echo "       where GAPPATH is a path to your GAP installation"
+    echo "       (The default for GAPPATH is \"../..\")"
+    echo
+    echo "Either your GAPPATH is incorrect or the GAP it is pointing to"
+    echo "is not properly compiled (do \"./configure && make\" there first)."
+    echo
+    echo "Aborting... No Makefile is generated."
+    echo
+    exit 1
+fi
+
+echo "Using settings from $GAPPATH/sysinfo.gap"
+sed -e "s;@GAPPATH@;$GAPPATH;g" Makefile.in > Makefile


### PR DESCRIPTION
- `configure` now supports `./configure --with-gaproot=GAPROOT` in addition to `./configure GAPROOT`
- `configure` also performs a check whether the given GAPROOT directory seems like a valid gap root
- `Makefile` now has a rule to re-run configure (to regenerate itself) if `Makefile.in` or `configure` or GAP's `sysinfo.gap` changed; this is very convenient when editing the build system
- pass `--enable-generic` to nauty's `configure` script, to disable use of `-march=native` which has caused us trouble in the past
- `Makefile`: linearized the `binaries` target to make it a bit easier to see what's going on, esp. when editing part of it

This puts it in line with e.g. datastructures and other packages
