### PR TITLE
Explicitly load primgrp in tst/testall.g

### DIFF
--- a/tst/testall.g
+++ b/tst/testall.g
@@ -1,4 +1,5 @@
 LoadPackage( "grape" );
+LoadPackage( "primgrp" );
 
 if IsBound(GAPInfo.SystemEnvironment.GRAPE_NAUTY) then
     if GAPInfo.SystemEnvironment.GRAPE_NAUTY = "true" then


### PR DESCRIPTION
The tests (and some manual examples) use `OnePrimitiveGroup`.

This is motivated by https://github.com/gap-system/gap/issues/2434